### PR TITLE
Solve background-map-not-displayed issue.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-			
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
 	<application android:label="@string/app_name" android:description="@string/app_description" android:icon="@drawable/ic_launcher" android:theme="@style/HighContrast">
 
 		<activity android:name="net.osmtracker.activity.TrackManager" android:label="@string/app_name">

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrack.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrack.java
@@ -5,13 +5,18 @@ import net.osmtracker.util.ThemeValidator;
 import net.osmtracker.view.DisplayTrackView;
 import net.osmtracker.db.TrackContentProvider;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup.LayoutParams;
 
 /**

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -18,20 +18,16 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.PathOverlay;
 import org.osmdroid.views.overlay.mylocation.SimpleLocationOverlay;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.ContentUris;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -156,11 +152,6 @@ public class DisplayTrackMap extends Activity {
 	 */
 	private SharedPreferences prefs = null;
 
-	/**
-	* Read storage REQUEST code
-	*/
-	final private int RC_READ_STORAGE = 1;
-
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -226,7 +217,7 @@ public class DisplayTrackMap extends Activity {
 	 */
 	public void selectTileSource() {
 		String mapTile = prefs.getString(OSMTracker.Preferences.KEY_UI_MAP_TILE, OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPNIK);
-		Log.e("TileMapName", mapTile);
+		Log.e("TileMapName active", mapTile);
 		osmView.setTileSource(selectMapTile(mapTile));
 	}
 	
@@ -239,11 +230,11 @@ public class DisplayTrackMap extends Activity {
 	 */
 	private ITileSource selectMapTile(String mapTile) {
 		try {
-			Log.e("TrySuccess", "TrySuccess");
 			Field f = TileSourceFactory.class.getField(mapTile);
 			return (ITileSource) f.get(null); 
 		} catch (Exception e) {
 			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
+			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
 			return TileSourceFactory.DEFAULT_TILE_SOURCE;
 		}
 	}
@@ -264,20 +255,6 @@ public class DisplayTrackMap extends Activity {
 	protected void onResume() {
 
 		super.onResume();
-
-//		if (!writeExternalStoragePermissionGranted()){
-//			Log.e("DisplayTrackMapWrite", "Permission asked");
-//			ActivityCompat.requestPermissions(this,
-//					new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, RC_READ_STORAGE);
-//		}
-//		else resumeActivity();
-
-//		if (!readExternalStoragePermissionGranted()){
-//			Log.e("DisplayTrackMapRead", "Permission asked");
-//			ActivityCompat.requestPermissions(this,
-//					new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 1);
-//		}
-
 		resumeActivity();
 
 	}
@@ -304,39 +281,6 @@ public class DisplayTrackMap extends Activity {
 		// Refresh way points
 		wayPointsOverlay.refresh();
 
-	}
-
-	private boolean readExternalStoragePermissionGranted(){
-		Log.e("CHECKING", "Read");
-		return ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
-	}
-
-	private boolean writeExternalStoragePermissionGranted(){
-		Log.e("CHECKING", "Write");
-		return ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
-	}
-
-	@Override
-	public void onRequestPermissionsResult(int requestCode,
-										   String permissions[], int[] grantResults) {
-		switch (requestCode) {
-			case RC_READ_STORAGE: {
-				// If request is cancelled, the result arrays are empty.
-				if (grantResults.length > 0
-						&& grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-
-					// permission was granted, yay! Do the
-					Log.e("RESULT", "Permission Granted");
-					resumeActivity();
-
-				} else {
-
-					// permission denied, boo! Disable the
-					// functionality that depends on this permission.
-					Log.e("RESULT", "Permission not Granted");
-				}
-			}
-		}
 	}
 
 	@Override

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,63 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-	<ListPreference android:title="@string/prefs_voicerec_duration"
-		android:key="voicerec.duration" android:entryValues="@array/prefs_voicerec_durations"
-		android:defaultValue="2" android:entries="@array/prefs_voicerec_durations"></ListPreference>
-	<CheckBoxPreference android:key="sound_enabled" android:title="@string/prefs_sound_enabled"
-		android:summary="@string/prefs_sound_enabled_summary" android:defaultValue="true"></CheckBoxPreference>
+	<ListPreference
+		android:title="@string/prefs_voicerec_duration"
+		android:key="voicerec.duration"
+		android:entryValues="@array/prefs_voicerec_durations"
+		android:defaultValue="2"
+		android:entries="@array/prefs_voicerec_durations" />
+	<CheckBoxPreference
+		android:key="sound_enabled"
+		android:title="@string/prefs_sound_enabled"
+		android:summary="@string/prefs_sound_enabled_summary"
+		android:defaultValue="true" />
 	<com.android.internal.preference.YesNoPreference android:key="osm.oauth.clear-data"
 		android:title="@string/prefs_osm_clear_oauth_data" android:summary="@string/prefs_osm_clear_oauth_data_summary"
 		android:dialogMessage="@string/prefs_osm_clear_oauth_data_dialog" android:dialogIcon="@android:drawable/ic_dialog_alert" />
 	
 	<PreferenceCategory android:title="@string/prefs_gps">
-		<Preference android:summary="@string/prefs_gps_os_settings_summary"
-			android:title="@string/prefs_gps_os_settings" android:key="gps.ossettings"></Preference>
-		<CheckBoxPreference android:key="gps.checkstartup"
-			android:title="@string/prefs_check_gps_startup" android:summary="@string/prefs_check_gps_startup_summary"
-			android:defaultValue="true"></CheckBoxPreference>
-		<CheckBoxPreference android:key="gps.ignoreclock"
-			android:title="@string/prefs_gps_ignore_clock" android:summary="@string/prefs_gps_ignore_clock_summary"
-			android:defaultValue="false"></CheckBoxPreference>
-		<EditTextPreference android:key="gps.logging.interval"
-			android:title="@string/prefs_gps_logging_interval" android:summary="@string/prefs_gps_logging_interval_summary"
-			android:defaultValue="0" android:inputType="number"></EditTextPreference>
-		<EditTextPreference android:key="gps.logging.min_distance"
-			android:title="@string/prefs_gps_logging_min_distance" android:summary="@string/prefs_gps_logging_min_distance_summary"
-			android:defaultValue="0" android:inputType="number"></EditTextPreference>
+		<Preference
+			android:summary="@string/prefs_gps_os_settings_summary"
+			android:title="@string/prefs_gps_os_settings"
+			android:key="gps.ossettings" />
+		<CheckBoxPreference
+			android:key="gps.checkstartup"
+			android:title="@string/prefs_check_gps_startup"
+			android:summary="@string/prefs_check_gps_startup_summary"
+			android:defaultValue="true" />
+		<CheckBoxPreference
+			android:key="gps.ignoreclock"
+			android:title="@string/prefs_gps_ignore_clock"
+			android:summary="@string/prefs_gps_ignore_clock_summary"
+			android:defaultValue="false" />
+		<EditTextPreference
+			android:key="gps.logging.interval"
+			android:title="@string/prefs_gps_logging_interval"
+			android:summary="@string/prefs_gps_logging_interval_summary"
+			android:defaultValue="0"
+			android:inputType="number" />
+		<EditTextPreference
+			android:key="gps.logging.min_distance"
+			android:title="@string/prefs_gps_logging_min_distance"
+			android:summary="@string/prefs_gps_logging_min_distance_summary"
+			android:defaultValue="0"
+			android:inputType="number" />
 	</PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/prefs_output">
 		<EditTextPreference android:key="logging.storage.dir"
 			android:defaultValue="/osmtracker" android:title="@string/prefs_storage_dir" android:dialogMessage="@string/prefs_storage_dir_hint"/>
-		<CheckBoxPreference android:key="gpx.directory_per_track" android:title="@string/prefs_output_one_dir_per_track"
-			android:summary="@string/prefs_output_one_dir_per_track_summary" android:defaultValue="true"></CheckBoxPreference>
+		<CheckBoxPreference
+			android:key="gpx.directory_per_track"
+			android:title="@string/prefs_output_one_dir_per_track"
+			android:summary="@string/prefs_output_one_dir_per_track_summary"
+			android:defaultValue="true" />
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />
-		<ListPreference android:key="gpx.accuracy" android:defaultValue="none" android:summary="@string/prefs_output_accuracy_summary"
-			android:title="@string/prefs_output_accuracy" android:entryValues="@array/prefs_output_accuracy_values"
-			android:entries="@array/prefs_output_accuracy_keys"></ListPreference>
-		<CheckBoxPreference android:key="gpx.hdop.approximation" android:title="@string/prefs_output_gpx_hdop_approximation"
-			android:summary="@string/prefs_output_gpx_hdop_approximation_summary" android:defaultValue="false"></CheckBoxPreference>
+		<ListPreference
+			android:key="gpx.accuracy"
+			android:defaultValue="none"
+			android:summary="@string/prefs_output_accuracy_summary"
+			android:title="@string/prefs_output_accuracy"
+			android:entryValues="@array/prefs_output_accuracy_values"
+			android:entries="@array/prefs_output_accuracy_keys" />
+		<CheckBoxPreference
+			android:key="gpx.hdop.approximation"
+			android:title="@string/prefs_output_gpx_hdop_approximation"
+			android:summary="@string/prefs_output_gpx_hdop_approximation_summary"
+			android:defaultValue="false" />
 		<ListPreference android:key="gpx.compass_heading" android:summary="@string/prefs_compass_heading_summary" android:title="@string/prefs_compass_heading" android:entryValues="@array/prefs_compass_heading_values" android:entries="@array/prefs_compass_heading_keys"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/prefs_ui">
-		<ListPreference android:defaultValue="none" android:key="ui.picture.source" android:title="@string/prefs_ui_picture_source"
-			android:summary="@string/prefs_ui_picture_source_summary" android:entries="@array/prefs_ui_picture_source_keys" android:entryValues="@array/prefs_ui_picture_source_values"></ListPreference>
-		<CheckBoxPreference android:key="ui.display_keep_on" android:title="@string/prefs_display_always_on"
-			android:summary="@string/prefs_display_always_on_summary" android:defaultValue="true"></CheckBoxPreference>
-		<ListPreference android:entries="@array/prefs_theme_keys" android:title="@string/prefs_theme"
-			android:entryValues="@array/prefs_theme_values" android:key="ui.theme" android:summary="@string/prefs_theme_summary" android:defaultValue="@style/DefaultTheme"></ListPreference>
+		<ListPreference
+			android:defaultValue="none"
+			android:key="ui.picture.source"
+			android:title="@string/prefs_ui_picture_source"
+			android:summary="@string/prefs_ui_picture_source_summary"
+			android:entries="@array/prefs_ui_picture_source_keys"
+			android:entryValues="@array/prefs_ui_picture_source_values" />
+		<CheckBoxPreference
+			android:key="ui.display_keep_on"
+			android:title="@string/prefs_display_always_on"
+			android:summary="@string/prefs_display_always_on_summary"
+			android:defaultValue="true" />
+		<ListPreference
+			android:entries="@array/prefs_theme_keys"
+			android:title="@string/prefs_theme"
+			android:entryValues="@array/prefs_theme_values"
+			android:key="ui.theme"
+			android:summary="@string/prefs_theme_summary"
+			android:defaultValue="@style/DefaultTheme" />
 		<PreferenceScreen android:title="@string/prefs_ui_buttons_layout" android:summary="@string/prefs_ui_buttons_layout_summary">
-			<intent android:action="launch_buttons_presets"></intent>
+			<intent android:action="launch_buttons_presets" />
 		</PreferenceScreen>
-		<CheckBoxPreference android:key="ui.displaytrack.osm" android:title="@string/prefs_displaytrack_osm"
-			android:summary="@string/prefs_displaytrack_osm_summary" android:defaultValue="false"></CheckBoxPreference>
-		<ListPreference android:entries="@array/prefs_map_tile_keys" android:title="@string/prefs_map_tile"
-			android:entryValues="@array/prefs_map_tile_values" android:key="ui.map.tile" android:summary="@string/prefs_map_tile_summary" android:defaultValue="MAPNIK"></ListPreference>
-		<ListPreference android:defaultValue="none" android:key="ui.orientation" android:title="@string/prefs_ui_orientation"
-			android:summary="@string/prefs_ui_orientation_summary" android:entries="@array/prefs_ui_orientation_options_keys" android:entryValues="@array/prefs_ui_orientation_options_values"></ListPreference>
+		<CheckBoxPreference
+			android:key="ui.displaytrack.osm"
+			android:title="@string/prefs_displaytrack_osm"
+			android:summary="@string/prefs_displaytrack_osm_summary"
+			android:defaultValue="false" />
+		<ListPreference
+			android:entries="@array/prefs_map_tile_keys"
+			android:title="@string/prefs_map_tile"
+			android:entryValues="@array/prefs_map_tile_values"
+			android:key="ui.map.tile"
+			android:summary="@string/prefs_map_tile_summary"
+			android:defaultValue="MAPNIK" />
+		<ListPreference
+			android:defaultValue="none"
+			android:key="ui.orientation"
+			android:title="@string/prefs_ui_orientation"
+			android:summary="@string/prefs_ui_orientation_summary"
+			android:entries="@array/prefs_ui_orientation_options_keys"
+			android:entryValues="@array/prefs_ui_orientation_options_values" />
 	</PreferenceCategory>
 
 


### PR DESCRIPTION
The error was caused because the **storage permissions** weren't allowed at the moment of displaying the track. The app needs to have access to phone storage to open the next path:

`storage/emulated/0/osmdroid/tiles/cahe.db`

so it can access the cache database.

Otherwise the background is not displayed. 

This PR asks for **storage permissions** before display the track selected in the previous activity (`TrackManager`).

The permissions are requested before start the `DisplayTrackMap` activity because otherwise the app flow will continue and will look for the path mentioned above before the user allow access to storage.

The changes were tested with two Android versions: 6.0 and 8.0.